### PR TITLE
Adding missing 'm.'

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -720,7 +720,7 @@ func (m Model) placeholderView() string {
 	valWidth := rw.StringWidth(m.Placeholder)
 	if m.Width > 0 && valWidth <= m.Width {
 		padding := max(0, m.Width-valWidth)
-		if valWidth+padding <= m.Width && pos < len(v) {
+		if valWidth+padding <= m.Width && m.pos < len(v) {
 			padding++
 		}
 		v += style(strings.Repeat(" ", padding))


### PR DESCRIPTION
As is the code won't compile and returns the following error.

```
# github.com/charmbracelet/bubbles/textinput
sticky-placeholder/textinput/textinput.go:723:37: undefined: pos
```

Adding the model reference solves the build problem, and your fix solves the problem where the width will shrink when displaying the placeholder text.